### PR TITLE
Make Read/Write File not modify sent options object

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -175,7 +175,9 @@
         options = options || {};
 
         if (options.encoding) {
-            options.ResponseContentEncoding = options.encoding;
+            options = extend(true, {
+                ResponseContentEncoding: options.encoding
+            }, options);
             delete options.encoding;
         }
 
@@ -229,7 +231,9 @@
         options = options || {};
 
         if (options.encoding) {
-            options.ContentEncoding = options.encoding;
+            options = extend(true, {
+                ContentEncoding: options.encoding
+            }, options);
             delete options.encoding;
         }
 

--- a/test/file.js
+++ b/test/file.js
@@ -125,9 +125,20 @@
             return expect(promise).to.eventually.be.fulfilled();
         });
 
-        it('should be able to write a file with encoding', function () {
+        it('should be able to write a file with utf8 encoding', function () {
             var fileText = '{ "test": "test" }';
             var options = {encoding: 'utf8'};
+            return bucketS3fsImpl.writeFile('test-file.json', fileText, options).then(function () {
+                return expect(bucketS3fsImpl.readFile('test-file.json', options)).to.eventually.satisfy(function (data) {
+                    expect(data.Body.toString()).to.equal(fileText);
+                    return true;
+                });
+            });
+        });
+
+        it('should be able to write a file with utf16 encoding', function () {
+            var fileText = '{ "test": "test" }';
+            var options = {encoding: 'utf16'};
             return bucketS3fsImpl.writeFile('test-file.json', fileText, options).then(function () {
                 return expect(bucketS3fsImpl.readFile('test-file.json', options)).to.eventually.satisfy(function (data) {
                     expect(data.Body.toString()).to.equal(fileText);

--- a/test/file.js
+++ b/test/file.js
@@ -127,8 +127,8 @@
 
         it('should be able to write a file with encoding', function () {
             var fileText = '{ "test": "test" }';
-            var options = {encoding: 'utf16'};
-            return bucketS3fsImpl.writeFile('test-file.json', fileText, {encoding: 'utf16'}).then(function () {
+            var options = {encoding: 'utf8'};
+            return bucketS3fsImpl.writeFile('test-file.json', fileText, options).then(function () {
                 return expect(bucketS3fsImpl.readFile('test-file.json', options)).to.eventually.satisfy(function (data) {
                     expect(data.Body.toString()).to.equal(fileText);
                     return true;


### PR DESCRIPTION
This PR makes it so that we don't modify the `options` object sent to the `readFile()` and `writeFile()` methods which can cause unexpected consequences if the object is re-used.