### PR TITLE
Update Read/Write File to Operate more like Node's FS

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -174,15 +174,8 @@
 
         options = options || {};
 
-        if (typeof options === 'function' || !options) {
-            options = { encoding: null };
-        } else if (typeof options === 'string') {
-            options = { encoding: options };
-        } else if (!options) {
-            options = { encoding: null };
-        } else if (typeof options !== 'object') {
-            throw new TypeError('Bad arguments');
-        }
+        // See: https://github.com/nodejs/node/blob/d6714ff1a48de5dcd9d3dfbb4b2e036efcd92b7c/lib/fs.js#L229-L235
+        options = handleReadWriteFileOptions(options);
 
         var encoding = options.encoding;
         if (options.encoding) {
@@ -245,15 +238,8 @@
 
         options = options || {};
 
-        if (typeof options === 'function' || !options) {
-            options = { encoding: null };
-        } else if (typeof options === 'string') {
-            options = { encoding: options };
-        } else if (!options) {
-            options = { encoding: null };
-        } else if (typeof options !== 'object') {
-            throw new TypeError('Bad arguments');
-        }
+        // See: https://github.com/nodejs/node/blob/d6714ff1a48de5dcd9d3dfbb4b2e036efcd92b7c/lib/fs.js#L1120-L1126
+        options = handleReadWriteFileOptions(options);
 
         if (options.encoding) {
             options = extend(true, {
@@ -964,6 +950,20 @@
                 }
             });
         });
+    }
+
+    function handleReadWriteFileOptions(options) {
+        if (typeof options === 'function' || !options) {
+            options = { encoding: null };
+        } else if (typeof options === 'string') {
+            options = { encoding: options };
+        } else if (!options) {
+            options = { encoding: null };
+        } else if (typeof options !== 'object') {
+            throw new TypeError('Bad arguments');
+        }
+
+        return options;
     }
 
     /*

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -174,6 +174,17 @@
 
         options = options || {};
 
+        if (typeof options === 'function' || !options) {
+            options = { encoding: null };
+        } else if (typeof options === 'string') {
+            options = { encoding: options };
+        } else if (!options) {
+            options = { encoding: null };
+        } else if (typeof options !== 'object') {
+            throw new TypeError('Bad arguments');
+        }
+
+        var encoding = options.encoding;
         if (options.encoding) {
             options = extend(true, {
                 ResponseContentEncoding: options.encoding
@@ -188,6 +199,10 @@
         }
 
         promise.then(function (data) {
+            // See: https://github.com/RiptideElements/s3fs/issues/37#issuecomment-135460856
+            if (encoding) {
+                return callback(null, data.Body.toString(encoding));
+            }
             callback(null, data.Body); // Keep this in line with the FS interface and only return the contents.
         }, function (reason) {
             callback(reason);
@@ -229,6 +244,16 @@
         }
 
         options = options || {};
+
+        if (typeof options === 'function' || !options) {
+            options = { encoding: null };
+        } else if (typeof options === 'string') {
+            options = { encoding: options };
+        } else if (!options) {
+            options = { encoding: null };
+        } else if (typeof options !== 'object') {
+            throw new TypeError('Bad arguments');
+        }
 
         if (options.encoding) {
             options = extend(true, {

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -167,25 +167,29 @@
     };
 
     S3fs.prototype.readFile = function (name, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = undefined;
-        }
+        var self = this;
+        var encoding;
+        var promise = new Promise(function(resolve) {
+            if (typeof options === 'function') {
+                callback = options;
+                options = undefined;
+            }
 
-        options = options || {};
+            options = options || {};
 
-        // See: https://github.com/nodejs/node/blob/d6714ff1a48de5dcd9d3dfbb4b2e036efcd92b7c/lib/fs.js#L229-L235
-        options = handleReadWriteFileOptions(options);
+            // See: https://github.com/nodejs/node/blob/d6714ff1a48de5dcd9d3dfbb4b2e036efcd92b7c/lib/fs.js#L229-L235
+            options = handleReadWriteFileOptions(options);
 
-        var encoding = options.encoding;
-        if (options.encoding) {
-            options = extend(true, {
-                ResponseContentEncoding: options.encoding
-            }, options);
-            delete options.encoding;
-        }
+            encoding = options.encoding;
+            if (options.encoding) {
+                options = extend(true, {
+                    ResponseContentEncoding: options.encoding
+                }, options);
+                delete options.encoding;
+            }
 
-        var promise = getObject(this.s3, this.bucket, s3Utils.toKey(s3Utils.joinPaths(this.path + s3Utils.toKey(name, this.bucket, this.path))), options);
+            resolve(getObject(self.s3, self.bucket, s3Utils.toKey(s3Utils.joinPaths(self.path + s3Utils.toKey(name, self.bucket, self.path))), options));
+        });
 
         if (!callback) {
             return promise;
@@ -231,24 +235,27 @@
     };
 
     S3fs.prototype.writeFile = function (name, data, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = undefined;
-        }
+        var self = this;
+        var promise = new Promise(function(resolve) {
+            if (typeof options === 'function') {
+                callback = options;
+                options = undefined;
+            }
 
-        options = options || {};
+            options = options || {};
 
-        // See: https://github.com/nodejs/node/blob/d6714ff1a48de5dcd9d3dfbb4b2e036efcd92b7c/lib/fs.js#L1120-L1126
-        options = handleReadWriteFileOptions(options);
+            // See: https://github.com/nodejs/node/blob/d6714ff1a48de5dcd9d3dfbb4b2e036efcd92b7c/lib/fs.js#L1120-L1126
+            options = handleReadWriteFileOptions(options);
 
-        if (options.encoding) {
-            options = extend(true, {
-                ContentEncoding: options.encoding
-            }, options);
-            delete options.encoding;
-        }
+            if (options.encoding) {
+                options = extend(true, {
+                    ContentEncoding: options.encoding
+                }, options);
+                delete options.encoding;
+            }
 
-        var promise = putObject(this.s3, this.bucket, s3Utils.toKey(s3Utils.joinPaths(this.path + s3Utils.toKey(name, this.bucket, this.path))), data, options);
+            resolve(putObject(self.s3, self.bucket, s3Utils.toKey(s3Utils.joinPaths(self.path + s3Utils.toKey(name, self.bucket, self.path))), data, options));
+        });
 
         if (!callback) {
             return promise;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3fs",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Implementation of Node.JS FS interface using Amazon Simple Storage Service (S3).",
   "keywords": [
     "s3fs",

--- a/test/file.js
+++ b/test/file.js
@@ -116,6 +116,10 @@
             return expect(bucketS3fsImpl.writeFile('test-file.json', '{ "test": "test" }')).to.eventually.be.fulfilled();
         });
 
+        it('should be able to write a file with only encoding from a string', function () {
+            return expect(bucketS3fsImpl.writeFile('test-file.json', '{ "test": "test" }', 'utf8')).to.eventually.be.fulfilled();
+        });
+
         it('should be able to write a file from a string with a callback', function () {
             return expect(new Promise(function (resolve, reject) {
                 bucketS3fsImpl.writeFile('test.json', '{ "test": "test" }', function (err, data) {
@@ -207,7 +211,7 @@
                     .then(function () {
                         return bucketS3fsImpl.copyFile('test-copy.json', 'test-copy-dos.json');
                     })
-                    .then(function() {
+                    .then(function () {
                         return bucketS3fsImpl.exists('test-copy.json');
                     })
             ).to.eventually.equal(true);
@@ -219,7 +223,7 @@
                         var testDirS3fsImpl = bucketS3fsImpl.clone('testDir');
                         return testDirS3fsImpl.copyFile('../testDir/../testDir/test-copy.json', '../testDir/../testDir/test-copy-dos.json');
                     })
-                    .then(function() {
+                    .then(function () {
                         return bucketS3fsImpl.exists('testDir/test-copy-dos.json');
                     })
             ).to.eventually.equal(true);
@@ -277,7 +281,7 @@
                     .then(function () {
                         return bucketS3fsImpl.unlink('test-delete.json');
                     })
-                    .then(function() {
+                    .then(function () {
                         return bucketS3fsImpl.readdirp('/');
                     })
             ).to.eventually.have.lengthOf(0);
@@ -289,7 +293,7 @@
                         var testDirS3fsImpl = bucketS3fsImpl.clone('testDir');
                         return testDirS3fsImpl.unlink('../testDir/test-delete.json');
                     })
-                    .then(function() {
+                    .then(function () {
                         return bucketS3fsImpl.readdirp('/');
                     })
             ).to.eventually.have.lengthOf(0);
@@ -472,7 +476,7 @@
             })).to.eventually.be.fulfilled();
         });
 
-        it('should be able to read the file as a stream', function () {
+        it('should be able to read a file as a stream', function () {
             return expect(bucketS3fsImpl.writeFile('test-read-stream.json', '{ "test": "test" }')
                     .then(function () {
                         return new Promise(function (resolve, reject) {
@@ -491,6 +495,60 @@
                         });
                     })
             ).to.eventually.be.fulfilled();
+        });
+
+        it('should be able to read a file with a callback', function () {
+            var contents = '{ "test": "test" }';
+            return expect(bucketS3fsImpl.writeFile('test-read-file-cb.json', contents)
+                    .then(function () {
+                        return new Promise(function (resolve, reject) {
+                            bucketS3fsImpl.readFile('test-read-file-cb.json', function (err, data) {
+                                if (err) {
+                                    return reject(err);
+                                }
+
+                                resolve(data);
+                            });
+                        });
+                    })
+            ).to.eventually.be.instanceOf(Buffer).and.to.satisfy(function (data) {
+                    expect(data.toString()).to.equal(contents);
+                    return true;
+                });
+        });
+
+        it('should be able to read a file with only encoding and a callback', function () {
+            var contents = '{ "test": "test" }';
+            return expect(bucketS3fsImpl.writeFile('test-read-file-encoding-cb.json', contents)
+                    .then(function () {
+                        return new Promise(function (resolve, reject) {
+                            bucketS3fsImpl.readFile('test-read-file-encoding-cb.json', 'utf8', function (err, data) {
+                                if (err) {
+                                    return reject(err);
+                                }
+
+                                resolve(data);
+                            });
+                        });
+                    })
+            ).to.eventually.be.a('string').and.equal(contents);
+        });
+
+        it('should be able to read a file with encoding in options and a callback', function () {
+            var contents = '{ "test": "test" }';
+            return expect(bucketS3fsImpl.writeFile('test-read-file-encoding-cb.json', contents)
+                    .then(function () {
+                        return new Promise(function (resolve, reject) {
+                            bucketS3fsImpl.readFile('test-read-file-encoding-cb.json', {encoding: 'utf8'}, function (err, data) {
+                                if (err) {
+                                    return reject(err);
+                                }
+
+                                resolve(data);
+                            });
+                        });
+                    })
+            ).to.eventually.be.a('string').and.equal(contents);
         });
 
         it('should be able to retrieve the stats of a file - stat(2)', function () {

--- a/test/file.js
+++ b/test/file.js
@@ -116,6 +116,10 @@
             return expect(bucketS3fsImpl.writeFile('test-file.json', '{ "test": "test" }')).to.eventually.be.fulfilled();
         });
 
+        it('shouldn\'t be able to write a file with invalid options', function () {
+            return expect(bucketS3fsImpl.writeFile('test-file.json', '{ "test": "test" }', 1)).to.eventually.be.rejectedWith(TypeError, 'Bad arguments');
+        });
+
         it('should be able to write a file with only encoding from a string', function () {
             return expect(bucketS3fsImpl.writeFile('test-file.json', '{ "test": "test" }', 'utf8')).to.eventually.be.fulfilled();
         });
@@ -142,6 +146,10 @@
 
             });
             return expect(promise).to.eventually.be.fulfilled();
+        });
+
+        it('shouldn\'t be able to read a file with invalid options', function () {
+            return expect(bucketS3fsImpl.readFile('test-file.json', 1)).to.eventually.be.rejectedWith(TypeError, 'Bad arguments');
         });
 
         it('should be able to write a file with utf8 encoding', function () {


### PR DESCRIPTION
Add functionality and tests around how we handle support for encoding in `readFile()` and `writeFile()` so that we are more in-line with how Node's FS works.

This way we are more in-line with how FS works on Node currently. Fixed #37 