### PR TITLE
Make Read File Promise Interface Similar to Callback Interface

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -192,7 +192,13 @@
         });
 
         if (!callback) {
-            return promise;
+            return promise.then(function (data) {
+                if (encoding) {
+                    return data.Body.toString(encoding);
+                }
+
+                return data.Body;
+            });
         }
 
         promise.then(function (data) {

--- a/test/file.js
+++ b/test/file.js
@@ -70,8 +70,8 @@
         it('should be able to read and write a file by going up a directory in a path', function () {
             var fileText = '{ "test": "test" }';
             return bucketS3fsImpl.writeFile('test-file.json', fileText).then(function () {
-                return expect(bucketS3fsImpl.readFile(bucketS3fsImpl.path + '../test-file.json', 'utf8')).to.eventually.satisfy(function (data) {
-                    expect(data).to.equal(fileText);
+                return expect(bucketS3fsImpl.readFile(bucketS3fsImpl.path + '../test-file.json')).to.eventually.satisfy(function (data) {
+                    expect(data.toString()).to.equal(fileText);
                     return true;
                 });
             });
@@ -80,8 +80,8 @@
         it('should be able to read and write a file by going out of the bucket path', function () {
             var fileText = '{ "test": "test" }';
             return bucketS3fsImpl.writeFile('../' + bucketS3fsImpl.path.slice(0, -1) + 'mock/' + 'test-file.json', fileText).then(function () {
-                return expect(bucketS3fsImpl.readFile('../' + bucketS3fsImpl.path.slice(0, -1) + 'mock/' + 'test-file.json', 'utf8')).to.eventually.satisfy(function (data) {
-                    expect(data).to.equal(fileText);
+                return expect(bucketS3fsImpl.readFile('../' + bucketS3fsImpl.path.slice(0, -1) + 'mock/' + 'test-file.json')).to.eventually.satisfy(function (data) {
+                    expect(data.toString()).to.equal(fileText);
                     return true;
                 });
             });
@@ -95,8 +95,8 @@
                 bucketS3fsImpl.writeFile('two/test-file.json', fileText)
             ]).then(function () {
                 var oneS3fsImpl = bucketS3fsImpl.clone('one');
-                return expect(oneS3fsImpl.readFile('../two/test-file.json', 'utf8')).to.eventually.satisfy(function (data) {
-                    expect(data).to.equal(fileText);
+                return expect(oneS3fsImpl.readFile('../two/test-file.json')).to.eventually.satisfy(function (data) {
+                    expect(data.toString()).to.equal(fileText);
                     return true;
                 });
             });
@@ -105,8 +105,8 @@
         it('should be able to read and write a file by going up a directory', function () {
             var fileText = '{ "test": "test" }';
             return bucketS3fsImpl.writeFile('../some/dir/test-file.json', fileText).then(function () {
-                return expect(bucketS3fsImpl.readFile('../some/dir/somethingInvalid/../test-file.json', 'utf8')).to.eventually.satisfy(function (data) {
-                    expect(data).to.equal(fileText);
+                return expect(bucketS3fsImpl.readFile('../some/dir/somethingInvalid/../test-file.json')).to.eventually.satisfy(function (data) {
+                    expect(data.toString()).to.equal(fileText);
                     return true;
                 });
             });
@@ -482,6 +482,15 @@
                     resolve(data);
                 });
             })).to.eventually.be.fulfilled();
+        });
+
+        it('should be able to read a file with only encoding specified', function () {
+            var fileData = '{ "test": "test" }';
+            return expect(bucketS3fsImpl.writeFile('test-read-encoding-only.json', fileData)
+                    .then(function () {
+                        return bucketS3fsImpl.readFile('test-read-encoding-only.json', 'utf8');
+                    })
+            ).to.eventually.equal(fileData);
         });
 
         it('should be able to read a file as a stream', function () {

--- a/test/file.js
+++ b/test/file.js
@@ -70,8 +70,8 @@
         it('should be able to read and write a file by going up a directory in a path', function () {
             var fileText = '{ "test": "test" }';
             return bucketS3fsImpl.writeFile('test-file.json', fileText).then(function () {
-                return expect(bucketS3fsImpl.readFile(bucketS3fsImpl.path + '../test-file.json')).to.eventually.satisfy(function (data) {
-                    expect(data.Body.toString()).to.equal(fileText);
+                return expect(bucketS3fsImpl.readFile(bucketS3fsImpl.path + '../test-file.json', 'utf8')).to.eventually.satisfy(function (data) {
+                    expect(data).to.equal(fileText);
                     return true;
                 });
             });
@@ -80,8 +80,8 @@
         it('should be able to read and write a file by going out of the bucket path', function () {
             var fileText = '{ "test": "test" }';
             return bucketS3fsImpl.writeFile('../' + bucketS3fsImpl.path.slice(0, -1) + 'mock/' + 'test-file.json', fileText).then(function () {
-                return expect(bucketS3fsImpl.readFile('../' + bucketS3fsImpl.path.slice(0, -1) + 'mock/' + 'test-file.json')).to.eventually.satisfy(function (data) {
-                    expect(data.Body.toString()).to.equal(fileText);
+                return expect(bucketS3fsImpl.readFile('../' + bucketS3fsImpl.path.slice(0, -1) + 'mock/' + 'test-file.json', 'utf8')).to.eventually.satisfy(function (data) {
+                    expect(data).to.equal(fileText);
                     return true;
                 });
             });
@@ -95,8 +95,8 @@
                 bucketS3fsImpl.writeFile('two/test-file.json', fileText)
             ]).then(function () {
                 var oneS3fsImpl = bucketS3fsImpl.clone('one');
-                return expect(oneS3fsImpl.readFile('../two/test-file.json')).to.eventually.satisfy(function (data) {
-                    expect(data.Body.toString()).to.equal(fileText);
+                return expect(oneS3fsImpl.readFile('../two/test-file.json', 'utf8')).to.eventually.satisfy(function (data) {
+                    expect(data).to.equal(fileText);
                     return true;
                 });
             });
@@ -105,8 +105,8 @@
         it('should be able to read and write a file by going up a directory', function () {
             var fileText = '{ "test": "test" }';
             return bucketS3fsImpl.writeFile('../some/dir/test-file.json', fileText).then(function () {
-                return expect(bucketS3fsImpl.readFile('../some/dir/somethingInvalid/../test-file.json')).to.eventually.satisfy(function (data) {
-                    expect(data.Body.toString()).to.equal(fileText);
+                return expect(bucketS3fsImpl.readFile('../some/dir/somethingInvalid/../test-file.json', 'utf8')).to.eventually.satisfy(function (data) {
+                    expect(data).to.equal(fileText);
                     return true;
                 });
             });
@@ -157,7 +157,7 @@
             var options = {encoding: 'utf8'};
             return bucketS3fsImpl.writeFile('test-file.json', fileText, options).then(function () {
                 return expect(bucketS3fsImpl.readFile('test-file.json', options)).to.eventually.satisfy(function (data) {
-                    expect(data.Body.toString()).to.equal(fileText);
+                    expect(data).to.equal(fileText);
                     return true;
                 });
             });
@@ -168,7 +168,7 @@
             var options = {encoding: 'utf16'};
             return bucketS3fsImpl.writeFile('test-file.json', fileText, options).then(function () {
                 return expect(bucketS3fsImpl.readFile('test-file.json', options)).to.eventually.satisfy(function (data) {
-                    expect(data.Body.toString()).to.equal(fileText);
+                    expect(data).to.equal(fileText);
                     return true;
                 });
             });

--- a/test/s3fs.js
+++ b/test/s3fs.js
@@ -120,10 +120,10 @@
             return expect(bucketS3fsImpl.writeFile('imAClone/test-file.json', '{ "test": "test" }')
                     .then(function () {
                         var s3fsClone = bucketS3fsImpl.clone('imAClone');
-                        return s3fsClone.readFile('test-file.json');
+                        return s3fsClone.readFile('test-file.json', 'utf8');
                     })
             ).to.eventually.satisfy(function (file) {
-                    expect(file.Body.toString()).to.be.equal('{ "test": "test" }');
+                    expect(file).to.be.equal('{ "test": "test" }');
                     return true;
                 });
         });

--- a/test/s3fs.js
+++ b/test/s3fs.js
@@ -120,10 +120,10 @@
             return expect(bucketS3fsImpl.writeFile('imAClone/test-file.json', '{ "test": "test" }')
                     .then(function () {
                         var s3fsClone = bucketS3fsImpl.clone('imAClone');
-                        return s3fsClone.readFile('test-file.json', 'utf8');
+                        return s3fsClone.readFile('test-file.json');
                     })
-            ).to.eventually.satisfy(function (file) {
-                    expect(file).to.be.equal('{ "test": "test" }');
+            ).to.eventually.satisfy(function (data) {
+                    expect(data.toString()).to.be.equal('{ "test": "test" }');
                     return true;
                 });
         });


### PR DESCRIPTION
This PR pulls in the changes from #42 and fixes #41. The changes were pulled in to a branch on the repository so that we can run them against S3 via Travis (this cannot be done via an external PR for security reasons).

