### PR TITLE
Return the ETag and modify date when using the copyFile method

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -343,11 +343,11 @@
                 Bucket: self.bucket,
                 Key: s3Utils.toKey(s3Utils.joinPaths(self.path + s3Utils.toKey(destinationFile))),
                 CopySource: [self.bucket, s3Utils.toKey(s3Utils.joinPaths(self.path + s3Utils.toKey(sourceFile)))].join('/')
-            }, function (err) {
+            }, function (err, data) {
                 if (err) {
                     return reject(err);
                 }
-                return resolve();
+                return resolve(data);
             });
         });
 


### PR DESCRIPTION
When using the copyFile method, it may be helpful to return the S3 information object to the promise.