### PR TITLE
Update Copy File to Return Copied Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ the bucket originally provided.
 
 ```js
 var fsImpl = new S3FS('test-bucket', options);
-fsImpl.copyFile('test-folder/test-file.txt', 'other-folder/test-file.txt').then(function() {
+fsImpl.copyFile('test-folder/test-file.txt', 'other-folder/test-file.txt').then(function(data) {
   // File was successfully copied
+  // Data contains details such as the `ETag` about the object. See [AWS SDK](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#copyObject-property) for details.
 }, function(reason) {
   // Something went wrong
 });

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -355,8 +355,8 @@
             return promise;
         }
 
-        promise.then(function () {
-            callback();
+        promise.then(function (data) {
+            callback(null, data);
         }, function (reason) {
             callback(reason);
         });

--- a/test/file.js
+++ b/test/file.js
@@ -227,7 +227,13 @@
         it('should be able to copy an object', function () {
             return expect(bucketS3fsImpl.writeFile('test-copy.json', '{}')
                 .then(function () {
-                    return bucketS3fsImpl.copyFile('test-copy.json', 'test-copy-dos.json');
+                    return expect(bucketS3fsImpl.copyFile('test-copy.json', 'test-copy-dos.json')).to.eventually.satisfy(function(data) {
+                        expect(data.ETag).to.equal(data.CopyObjectResult.ETag);
+                        expect(data.CopyObjectResult.ETag).to.equal('"99914b932bd37a50b983c5e7c90ae93b"');
+                        expect(data.LastModified).to.equal(data.CopyObjectResult.LastModified);
+                        expect(data.CopyObjectResult.LastModified).to.be.ok();
+                        return true;
+                    });
                 })
                 .then(function () {
                     return bucketS3fsImpl.exists('test-copy.json');
@@ -259,7 +265,13 @@
                         });
                     });
                 })
-            ).to.eventually.be.fulfilled();
+            ).to.eventually.satisfy(function(data) {
+                expect(data.ETag).to.equal(data.CopyObjectResult.ETag);
+                expect(data.CopyObjectResult.ETag).to.equal('"99914b932bd37a50b983c5e7c90ae93b"');
+                expect(data.LastModified).to.equal(data.CopyObjectResult.LastModified);
+                expect(data.CopyObjectResult.LastModified).to.be.ok();
+                return true;
+            });
         });
 
         it('should be able to get the head of an object', function () {


### PR DESCRIPTION
This PR adds tests & updates the documentation for `s3fs.copyFile(...)` to represent and test for the data from copying a file being returned in both callback and promise form. This was originally requested & implemented with #53 