### PR TITLE
Fix Head Object Callback Not Returning Data

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -482,8 +482,8 @@
             return promise;
         }
 
-        promise.then(function () {
-            callback();
+        promise.then(function (data) {
+            callback(null, data);
         }, function (reason) {
             callback(reason);
         });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
   "name": "s3fs",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "dependencies": {
     "aws-sdk": {
-      "version": "2.2.23",
+      "version": "2.2.30",
       "from": "aws-sdk@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.2.23.tgz"
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.2.30.tgz"
     },
     "bluebird": {
       "version": "2.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3fs",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Implementation of Node.JS FS interface using Amazon Simple Storage Service (S3).",
   "keywords": [
     "s3fs",

--- a/test/file.js
+++ b/test/file.js
@@ -279,7 +279,14 @@
                 .then(function () {
                     return bucketS3fsImpl.headObject('test-head.json');
                 })
-            ).to.eventually.be.fulfilled();
+            ).to.eventually.satisfy(function(data) {
+                expect(data.AcceptRanges).to.equal('bytes');
+                expect(data.ContentLength).to.equal('2');
+                expect(data.ETag).to.equal('"99914b932bd37a50b983c5e7c90ae93b"');
+                expect(data.ContentType).to.equal('application/octet-stream');
+                expect(data.LastModified).to.be.ok();
+                return true;
+            });
         });
 
         it('should be able to get the head of an object when going up a directory', function () {
@@ -288,7 +295,14 @@
                     var testDirS3fsImpl = bucketS3fsImpl.clone('testDir');
                     return testDirS3fsImpl.headObject('../testDir/test-head.json');
                 })
-            ).to.eventually.be.fulfilled();
+            ).to.eventually.satisfy(function(data) {
+                expect(data.AcceptRanges).to.equal('bytes');
+                expect(data.ContentLength).to.equal('2');
+                expect(data.ETag).to.equal('"99914b932bd37a50b983c5e7c90ae93b"');
+                expect(data.ContentType).to.equal('application/octet-stream');
+                expect(data.LastModified).to.be.ok();
+                return true;
+            });
         });
 
         it('should be able to get the head of an object with a callback', function () {
@@ -303,7 +317,14 @@
                         });
                     });
                 })
-            ).to.eventually.be.fulfilled();
+            ).to.eventually.satisfy(function(data) {
+                expect(data.AcceptRanges).to.equal('bytes');
+                expect(data.ContentLength).to.equal('2');
+                expect(data.ETag).to.equal('"99914b932bd37a50b983c5e7c90ae93b"');
+                expect(data.ContentType).to.equal('application/octet-stream');
+                expect(data.LastModified).to.be.ok();
+                return true;
+            });
         });
 
         it('should be able to delete a file', function () {


### PR DESCRIPTION
This PR fixes the `headObject` callback handling so that it actually returns data when using the callback. It also adds expectations to the tests for `headObject` to ensure we are getting the correct data back.

Fixes #56 