### PR TITLE
Make copyFile take s3.copyObject options

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,13 @@ var fsImpl = new S3FS('test-bucket/test-folder', options);
 var fsImplStyles = fsImpl.clone('styles');
 ```
 
-### s3fs.copyFile(sourcePath, destinationPath[, callback])
+### s3fs.copyFile(sourcePath, destinationPath[, options, callback])
 Allows a file to be copied from one path to another path within the same bucket. Paths are relative to
 the bucket originally provided.
 
 * sourceFile `String`. **Required**. Relative path to the source file
 * destinationFile `String`. **Required**. Relative path to the destination file
+* options `Object`. _Optional_. The options to be used when copying the file. See [AWS SDK](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#copyObject-property)
 * callback `Function`. _Optional_. Callback to be used, if not provided will return a Promise
 
 ```js

--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -331,17 +331,25 @@
      *
      * @param sourceFile `String`. **Required**. Relative path to the source file
      * @param destinationFile `String`. **Required**. Relative path to the destination file
+     * @param options `Object`. _Optional_. The options to be used when copying the file. See [AWS SDK](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#copyObject-property)
      * @param callback `Function`. _Optional_. Callback to be used, if not provided will return a Promise
      * @returns {Promise|*} Returns a `Promise` if a callback is not provided
      */
-    S3fs.prototype.copyFile = function (sourceFile, destinationFile, callback) {
+    S3fs.prototype.copyFile = function (sourceFile, destinationFile, options, callback) {
         var self = this;
         var promise = new Promise(function (resolve, reject) {
-            self.s3.copyObject({
+            if (typeof options === 'function') {
+                callback = options;
+                options = undefined;
+            }
+
+            options = options || {};
+
+            self.s3.copyObject(extend(true, options, {
                 Bucket: self.bucket,
                 Key: s3Utils.toKey(s3Utils.joinPaths(self.path + s3Utils.toKey(destinationFile))),
                 CopySource: [self.bucket, s3Utils.toKey(s3Utils.joinPaths(self.path + s3Utils.toKey(sourceFile)))].join('/')
-            }, function (err, data) {
+            }), function (err, data) {
                 if (err) {
                     return reject(err);
                 }

--- a/test/file.js
+++ b/test/file.js
@@ -265,6 +265,19 @@
             });
         });
 
+        it('should be able to copy a file with options', function () {
+            return bucketS3fsImpl.writeFile('test-copy.json', '{}')
+                .then(function () {
+                    var options = { ContentType: 'application/json', MetadataDirective: 'REPLACE' };
+                    return bucketS3fsImpl.copyFile('test-copy.json', 'test-copy-dos.json', options);
+                })
+                .then(function () {
+                    return expect(bucketS3fsImpl.readFile('test-copy-dos.json')).to.eventually.satisfy(function (data) {
+                        expect(data.ContentType).to.equal('application/json');
+                    });
+                });
+        });
+
         it('should be able to get the head of an object', function () {
             return expect(bucketS3fsImpl.writeFile('test-head.json', '{}')
                 .then(function () {


### PR DESCRIPTION
Fixes #162 

Allow changing Metadata when copying files. Most importantly, this allows setting `ACL` when , which otherwise doesn't get copied:

```js
s3fs.copyFile('foo', 'bar', { ACL: 'public-read' })
```

Or set any other metadata with

```js
s3fs.copyFile('foo', 'bar', { MetadataDirective: 'REPLACE', Expires: new Date() })
```