### PR TITLE
Infinite loop deleting folder with 999+ files #203

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -852,7 +852,8 @@
                 });
 
                 if (data.IsTruncated) {
-                    return listAllObjects(s3, bucket, prefix, delimiter, data.NextMarker).then(function (contents) {
+                    var nextKeyMarker = data.Contents[data.Contents.length - 1].Key;
+                    return listAllObjects(s3, bucket, prefix, delimiter, nextKeyMarker ).then(function (contents) {
                         resolve(contentsList.concat(contents));
                     }, function (reason) {
                         reject(reason);
@@ -883,7 +884,8 @@
                     return item;
                 });
                 if (data.IsTruncated) {
-                    return listAllObjectsFiles(s3, bucket, prefix, delimiter, data.NextMarker).then(function (files) {
+                    var nextKeyMarker = data.Contents[data.Contents.length - 1].Key;
+                    return listAllObjectsFiles(s3, bucket, prefix, delimiter, nextKeyMarker).then(function (files) {
                         resolve(fileList.concat(files));
                     }, function (reason) {
                         reject(reason);


### PR DESCRIPTION
As you can read in #203,  listObjects will not actually return a netKeyMarker  (explained in aws-sdk-js project https://github.com/aws/aws-sdk-js/issues/53).  You have to calculate it manually:  the last object key returned in data.Contents must be used as nextKeyMarker