### PR TITLE
Fix infinite loop while listing objects

### DIFF
--- a/lib/s3fs.js
+++ b/lib/s3fs.js
@@ -851,8 +851,16 @@
                     return item && item.Key;
                 });
 
+                var nextMarker = data.NextMarker;
                 if (data.IsTruncated) {
-                    return listAllObjects(s3, bucket, prefix, delimiter, data.NextMarker).then(function (contents) {
+                    if (typeof nextMarker === 'undefined') {
+                        // Per Amazon docs: If the response does not include the NextMaker and it is truncated,
+                        // you can use the value of the last Key in the response as the marker in the subsequent
+                        // request to get the next set of object keys.
+                        nextMarker = data.Contents[data.Contents.length - 1].Key;
+                    }
+
+                    return listAllObjects(s3, bucket, prefix, delimiter, nextMarker).then(function (contents) {
                         resolve(contentsList.concat(contents));
                     }, function (reason) {
                         reject(reason);
@@ -882,8 +890,17 @@
 
                     return item;
                 });
+
+                var nextMarker = data.NextMarker;
                 if (data.IsTruncated) {
-                    return listAllObjectsFiles(s3, bucket, prefix, delimiter, data.NextMarker).then(function (files) {
+                    if (typeof nextMarker === 'undefined') {
+                        // Per Amazon docs: If the response does not include the NextMaker and it is truncated,
+                        // you can use the value of the last Key in the response as the marker in the subsequent
+                        // request to get the next set of object keys.
+                        nextMarker = data.Contents[data.Contents.length - 1].Key;
+                    }
+
+                    return listAllObjectsFiles(s3, bucket, prefix, delimiter, nextMarker).then(function (files) {
                         resolve(fileList.concat(files));
                     }, function (reason) {
                         reject(reason);


### PR DESCRIPTION
NextMarker isn't always returned from listObjects API, so listing objects could turn into infinite loop. Please refer to the doc: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html